### PR TITLE
Adding a new page to aid users to transform from WUM/In-place to Updates

### DIFF
--- a/en/docs/updates/best-practices.md
+++ b/en/docs/updates/best-practices.md
@@ -22,4 +22,12 @@ Here are the guidelines and recommendations to receive best update experience wi
 !!! Note  
     Whenever you apply an update WSO2 recommends you to apply the updates to lower environments, run tests and update the 
     production environment.
-    
+<br>
+4.  Getting Updates to a lockdown Environment <br>
+    The best practice to disseminate updates to production environment with no internet connection is quite easy. <br>
+    First [receive the updates](../update-tool/#update-commands-for-os) in a lower environment that is connected to the internet. Test the environment thoroughly.
+    Perform security checks mandate by your organization and verify the updated pack. Last moved the verified pack to lockdown environment securely.
+    <br><br>
+5. Use a Configuration Management tool. <br>
+   There are a myriad of benefits of using Configuration Management Tool. WSO2 advise the use of Configuration Management Tool such as [Puppet and Ansible](../faq/#what-are-the-recommended-configuration-management-tools-to-deploy-configurations-to-client-nodes) to carry configuration changes flawlessly.
+   Read more on our [Continuous Update Document](../continuous-update).

--- a/en/docs/updates/best-practices.md
+++ b/en/docs/updates/best-practices.md
@@ -24,10 +24,10 @@ Here are the guidelines and recommendations to receive best update experience wi
     production environment.
 <br>
 4.  Getting Updates to a lockdown Environment <br>
-    The best practice to disseminate updates to production environment with no internet connection is quite easy. <br>
+    The best practices disseminating updates to production environment with no internet connection is as follows: <br>
     First [receive the updates](../update-tool/#update-commands-for-os) in a lower environment that is connected to the internet. Test the environment thoroughly.
-    Perform security checks mandate by your organization and verify the updated pack. Last moved the verified pack to lockdown environment securely.
+    Perform security checks mandate by your organization and verify the updated pack. Last move the verified pack to the lockdown environment securely.
     <br><br>
 5. Use a Configuration Management tool. <br>
-   There are a myriad of benefits of using Configuration Management Tool. WSO2 advise the use of Configuration Management Tool such as [Puppet and Ansible](../faq/#what-are-the-recommended-configuration-management-tools-to-deploy-configurations-to-client-nodes) to carry configuration changes flawlessly.
+   There are a myriad of benefits of using a Configuration Management Tool. WSO2 advise the use of Configuration Management Tool such as [Puppet and Ansible](../faq/#what-are-the-recommended-configuration-management-tools-to-deploy-configurations-to-client-nodes) to carry configuration changes flawlessly.
    Read more on our [Continuous Update Document](../continuous-update).

--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -124,26 +124,7 @@ Update tool client supports use of flags for user input values and exit codes fo
    
    * Use exit codes
    
-   <img src="../../assets/img/updates/exit-code.png" width="700"> 
-   
-### How do I migrate from WUM and In-place to Updates 2.0 ?
-
-* Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool 
-client available inside `<product_home>/bin` directory. 
-* Run the [Update commands](../../updates/update-tool/) on top of the update tool. This will 
-update the product pack to comply with Updates 2.0
-
-### How can a user merge the *WUM Diff* manually to get updates using WSO2 Updates 2.0?
-To get Updates using the new WSO2 Updates model follow the steps below<br>
-
-1. First get the newest product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0). <br>
-2. Apply [WUM diff](https://docs.wso2.com/display/updates100/WUM+Commands+Guide#WUMCommandsGuide-wumdiff) as you have been doing before to a copy of product pack (which contain your customizations). <br>
-
-!!! Note
-    The diff ZIP is created in the location from where you executed the diff command.
-<br>
-3. Now your current pack is congruent with WSO2 Update 2.0, thus you are able to run the [Updates tool](../../updates/update-tool/) and receive WSO2 Updates.<br>
-4. Test the updated product distribution and deploy it in your production environment.
+   <img src="../../assets/img/updates/exit-code.png" width="700">
 
 ### Are the updates I get from the Updates Client is secure and assures authenticity?
 The <strong>Update tool</strong> communicates with the <strong>WSO2 Update Service</strong> to get details of the updates that need to be downloaded and applied. During this communication, 

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -1,6 +1,6 @@
 ### How do I migrate from WUM and In-place to Updates 2.0?
 
-* Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool
+* Update the current product pack to the latest update level using WUM or in-place tool. This will make the new Update tool
   client available inside `<product_home>/bin` directory.
 * Run the [Update commands](../../updates/update-tool/) on top of the update tool. This will
   update the product pack to comply with Updates 2.0

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -21,7 +21,7 @@ To get Updates using the new WSO2 Updates model follow the steps below<br>
 It is not mandatory to have a configuration management tool configured, but having a configuration management tool makes the continuous updates process easy, 
 and it aids configuration with less possibility of human error.
 
-### what’s are the correct steps to apply the same Update level to all the nodes in the deployment if the user has not configured a configuration management tool?
+### What are the correct steps to apply the same Update level to all the nodes in the deployment if a configuration management tool is not being used?
 In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 
 as the manual intervention may lead to some flaws. <br>
 Steps to apply the same update level across all node: <br>

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -28,8 +28,8 @@ and it aids configuration with less possibility of human errors.
 Refer [APIM Ansible repository Documentation](https://github.com/wso2/ansible-apim/tree/3.2.x#including-custom-keystore-and-truststore) to get an insight on customizing keystore and truststore configurations that are integrated with a configuration management tool.
 
 ### How to persist customizations done on the servers during each update?
-1. If there are .jar or UI customization those changes should be done in configuration management server.Those changes should also be pushed to your forked repository, for future use.<br>
-2. The customized files should be in the sub-directories of the `/files` directory. (Particularly, all .jar files and UI customizations should be added to the `misc` folder.)<br>
+1. If there are .jar or UI customization those changes should be done in configuration management server. Those changes should also be pushed to your forked repository, for future use.<br>
+2. The customized files should be in the sub-directories of the `files` directory. (Particularly, all .jar files and UI customizations should be added to the `misc` folder.)<br>
 3. Next you need to change the script to include [group customizations/changes](https://github.com/wso2/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml). On the contrary, if there are any [role specific changes](https://github.com/wso2/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml) the script changes should be performed in the respective role(s).
 
 ### What are the correct steps to apply the same Update level to all the nodes in the deployment if a configuration management tool is not being used?

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -37,7 +37,7 @@ Then, run different profiles on those environments as needed.
 If a Configuration Management Tool is being used, follow the steps below to convert to the new updates model.<br>
 The respective product pack lies in the `files/packs` directory, to migrate to updates2.0 seamlessly you have to make both the product pack, and the `/scripts/update.sh` file compatible with WSO2 Updates 2.0.
 <br>
-- To update the **product pack** - Go to` scripts` directory and run the './update.sh' script.<br>
+- To update the **product pack** - Go to` scripts` directory and run the `./update.sh` script.<br>
 - To update **/scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tag, in this example WSO2 APIM.
 
   ``

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -7,15 +7,16 @@
 
 ### How can a user currently using *WUM Diff* migrate to WSO2 Updates 2.0?
 To get updates using the new WSO2 Updates model follow the steps below: <br>
-1. First, get the newest product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0).<br>
-2. Apply [WUM diff](https://docs.wso2.com/display/updates100/WUM+Commands+Guide#WUMCommandsGuide-wumdiff) as you have been doing before to a copy of product pack (which contain your customizations). <br>
+1. First, get the updated product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0).<br>
+2. Run [WUM diff](https://docs.wso2.com/display/updates100/WUM+Commands+Guide#WUMCommandsGuide-wumdiff) command as you have been doing before to create a zip file (which contains a diff between timestamps you have specified). <br>
+3. Perform [steps 4 to 9](https://docs.wso2.com/display/updates100/Getting+Continuous+Updates) stated in the document.
 
-!!! Note
-    The diff ZIP is created in the location from where you executed the diff command.
+!!! Info
+    Now you have updated the product pack to the up to date state using the WUM model. After updating, you have the required tools to get updates from Update2.0 model in the future. <br> Read about the new [Update2.0 model](https://wso2.com/updates).
 <br>
-3. Run the new Update Tool (e.g., wso2update_linux for linux users) refer [Update commands](../../updates/update-tool/) for other OS's. This will update the product pack to comply with WSO2 Updates 2.0, and the product pack will be in its latest update level.<br>
-4. Now your current pack is congruent with WSO2 Updates 2.0.<br>
-5. Test the updated product distribution and deploy it in your production environment.
+4. Run the new Update Tool (e.g., wso2update_linux for linux users) refer [Update commands](../../updates/update-tool/) for other OS's. This will update the product pack to comply with WSO2 Updates 2.0, and the product pack will be in its latest update level.<br>
+5. Now your current pack is congruent with WSO2 Updates 2.0.<br>
+6. Test the updated product distribution and deploy it in your production environment.
 
 ### Does the new WSO2 Updates 2.0 support a command similar to *WUM Diff*?
 No, Wum diff in the older/WUM model requires manual intervention. Therefore, it is prone to errors as a result commands that need manual file copying task were excluded from the updates 2.0
@@ -63,5 +64,5 @@ Now your updates setup is compatible with the new updates model. Thus, in the fu
 3. Considering the example mentioned above, Choose wso2am as the repository name.<br>
     Docker images with updates:<br>
     1. If you are using docker images in WUM with **three digit version** like wso2am:3.2.0 then switch to e.g.,3.2.0.0 to get docker images created using the new WSO2 updates 2.0. <br>
-    2. Using the WUM model if you have used docker images **with timestamp** like wso2am:3.2.0.1612370755920.2 then switch to an image with specific update level for example wso2am:3.2.0.8 using the new WSO2 updates 2.0<br>
+    2. Using the WUM model if you have used docker images **with a timestamp** like wso2am:3.2.0.1612370755920.2 then switch to an image with specific update level for example wso2am:3.2.0.8 using the new WSO2 updates 2.0<br>
     

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -46,10 +46,10 @@ Then, run different profiles on those environments as needed.
 
 ### How to migrate from WUM to the new Updates model if a Configuration Management Tool is being used ?
 If a Configuration Management Tool is being used, follow the steps below to convert to the new updates model.<br>
-The respective product pack lies in the `files/packs` directory, to migrate to updates 2.0 seamlessly you have to make both the product pack, and the `/scripts/update.sh` file compatible with Updates 2.0.
+The respective product pack lies in the `files/packs` directory, to migrate to updates 2.0 seamlessly you have to make both the product pack, and the `scripts/update.sh` file compatible with Updates 2.0.
 <br>
 - To update the **product pack** - Go to` scripts` directory and run the `./update.sh` script.<br>
-- To update **/scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tags, in this example WSO2 APIM.
+- To update **scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tags, in this example WSO2 APIM.
 
   ``
     git checkout v3.2.0.3

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -1,4 +1,4 @@
-### How do I migrate from WUM and In-place to Updates 2.0 ?
+### How do I migrate from WUM and In-place to Updates 2.0?
 
 * Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool
   client available inside `<product_home>/bin` directory.

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -40,11 +40,11 @@ The Following steps are used to get latest WSO2 APIM updates using Ansible as a 
 3. Checkout tag 3.2.0.x take the latest tag - Ansible scripts will be compatible with the new update model<br>
 4. Take future updates by running the `.update.sh` command. <br>
 
-### A customer who runs on a containerized deployment, How to differentiate docker images created with new updates from WSO2 Docker Repository?
+### How to differentiate docker images created with new updates from WSO2 Docker Repository?
 1. Login to [WSO2 Docker Repository](https://docker.wso2.com/) <br>
 2. In the shown list, choose the product that is used in your deployment environment (To easily explain we will use WSO2 APIM as a product).<br>
 3. Considering the example mentioned above, Choose wso2am as the repository name.<br>
     Docker images with updates:<br>
-    1. If user is using **three digit version** like wso2am:3.2.0 then switch to e.g.,3.2.0.0 to get docker images created with updates. <br>
-    2. If the customer was **using timestamp** image like wso2am:3.2.0.1612370755920.2 they can switch to an image with specific update level wso2am:3.2.0.8 <br>
+    1. If you are using docker images in WUM with **three digit version** like wso2am:3.2.0 then switch to e.g.,3.2.0.0 to get docker images created using the new WSO2 updates 2.0. <br>
+    2. Using the WUM model if you have used docker images **with timestamp** like wso2am:3.2.0.1612370755920.2 then switch to an image with specific update level for example wso2am:3.2.0.8 using the new WSO2 updates 2.0<br>
     

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -1,4 +1,4 @@
-### How do I migrate from WUM and In-place to Updates 2.0 ?
+### How do I migrate from WUM and In-place to Updates 2.0?
 
 * Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool
   client available inside `<product_home>/bin` directory.
@@ -17,7 +17,7 @@ To get Updates using the new WSO2 Updates model follow the steps below<br>
 3. Now your current pack is congruent with WSO2 Update 2.0, thus you are able to run the [Updates tool](../../updates/update-tool/) and receive WSO2 Updates.<br>
 4. Test the updated product distribution and deploy it in your production environment.
 
-### Is it mandatory to have a configuration management tool configured or can we take the Updates manually ?
+### Is it mandatory to have a configuration management tool configured or can we take the Updates manually?
 It is not mandatory to have a configuration management tool configured, but having a configuration management tool makes the continuous updates process easy, 
 and it aids configuration with less possibility of human error.
 
@@ -29,7 +29,7 @@ Steps to apply the same update level across all node: <br>
 2. Run all testcases and verify the update in that environment.<br>
 3. Propagate the updates to production environment (using rolling updates, Canary or Blue-green update methods).
 
-### If nodes are started with product profiles, how to take the manual Updates ?
+### If nodes are started with product profiles, how to take the manual Updates?
 First take the update of the base product and thereafter distribute the updated pack to other deployment environments. 
 Then, run different profiles on those environments as needed.
 

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -25,7 +25,7 @@ and it aids configuration with less possibility of human error.
 In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 
 as the manual intervention may lead to some flaws. <br>
 Steps to apply the same update level across all node: <br>
-1. Apply the update to a pre-production environment.<br>
+1. In a pre-production environment, update to the required update level using the --level flag (e.g., ./wso2update_linux --level 10)<br>
 2. Run all testcases and verify the update in that environment.<br>
 3. Propagate the updates to production environment (using rolling updates, Canary or Blue-green update methods).
 

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -24,6 +24,13 @@ No, Wum diff in the older/WUM model requires manual intervention. Therefore, it 
 It is not mandatory to have a configuration management tool configured, but having a configuration management tool makes the continuous updates process easy, 
 and it aids configuration with less possibility of human errors.
 
+### How the keystore and truststore configurations are incorporated with a configuration management tool?
+Refer [APIM Ansible repository Documentation](https://github.com/wso2/ansible-apim/tree/3.2.x#including-custom-keystore-and-truststore) to get an insight on customizing keystore and truststore configurations that are integrated with a configuration management tool.
+
+### How to persist customizations done on the servers during each update?
+if there are .jar or UI customization those changes should be done on the base pack of the Configuration Management Tool. (e.g., APIM 3.2.0 ansible the customized files should be in `/files` in the suitable directory. further, all .jar files should be added to the `misc` folder)
+next you need to change the script[common task](https://github.com/chamindi-a/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml) to include group customizations or changes. If there are any role specific changes the script changes should be performed in the required role(s).
+
 ### What are the correct steps to apply the same Update level to all the nodes in the deployment if a configuration management tool is not being used?
 In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 
 as the manual intervention may lead to some flaws. <br>

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -33,13 +33,19 @@ Steps to apply the same update level across all node: <br>
 First take the update of the base product and thereafter distribute the updated pack to other deployment environments. 
 Then, run different profiles on those environments as needed.
 
-### How to use Configuration Management Tool to get WUM updates?
-The Following steps are used to get latest WSO2 APIM updates using Ansible as a Configuration Management Tool.<br>
-1. Folk the newest WSO2 APIM Pack for the latest tag. <br>
-2. Run the `./update.sh` and update the pack - by performing this action product pack takes its latest state<br>
-3. Checkout tag 3.2.0.x take the latest tag - Ansible scripts will be compatible with the new update model<br>
-4. Take future updates by running the `./update.sh` command. <br>
+### How to migrate from WUM to the new Updates model if a Configuration Management Tool is being used ?
+If a Configuration Management Tool is being used, follow the steps below to convert to the new updates model.<br>
+The respective product pack lies in the `files/packs` directory, to migrate to updates2.0 seamlessly you have to make both the product pack, and the `/scripts/update.sh` file compatible with WSO2 Updates 2.0.
+<br>
+- To update the **product pack** - Go to` scripts` directory and run the './update.sh' script.<br>
+- To update **/scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tag, in this example WSO2 APIM.
 
+  ``
+            git checkout v3.2.0.3
+  ``
+   
+Now your updates setup is compatible with the new updates model. Thus, in the future when the `update.sh` script is executed updates will be delivered using the new updates model.
+      
 ### How to differentiate docker images created with new updates from WSO2 Docker Repository?
 1. Login to [WSO2 Docker Repository](https://docker.wso2.com/) <br>
 2. In the shown list, choose the product that is used in your deployment environment (To easily explain we will use WSO2 APIM as a product).<br>

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -1,0 +1,50 @@
+### How do I migrate from WUM and In-place to Updates 2.0 ?
+
+* Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool
+  client available inside `<product_home>/bin` directory.
+* Run the [Update commands](../../updates/update-tool/) on top of the update tool. This will
+  update the product pack to comply with Updates 2.0
+
+### How can a user merge the *WUM Diff* manually to get updates using WSO2 Updates 2.0?
+To get Updates using the new WSO2 Updates model follow the steps below<br>
+
+1. First get the newest product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0). <br>
+2. Apply [WUM diff](https://docs.wso2.com/display/updates100/WUM+Commands+Guide#WUMCommandsGuide-wumdiff) as you have been doing before to a copy of product pack (which contain your customizations). <br>
+
+!!! Note
+    The diff ZIP is created in the location from where you executed the diff command.
+<br>
+3. Now your current pack is congruent with WSO2 Update 2.0, thus you are able to run the [Updates tool](../../updates/update-tool/) and receive WSO2 Updates.<br>
+4. Test the updated product distribution and deploy it in your production environment.
+
+### Is it mandatory to have a configuration management tool configured or can we take the Updates manually ?
+It is not mandatory to have a configuration management tool configured, but having a configuration management tool makes the continuous updates process easy, 
+and it aids configuration with less possibility of human error.
+
+### what’s are the correct steps to apply the same Update level to all the nodes in the deployment if the user has not configured a configuration management tool?
+In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 
+as the manual intervention may lead to some flaws. <br>
+Steps to apply the same update level across all node: <br>
+1. Apply the update to a pre-production environment.<br>
+2. Run all testcases and verify the update in that environment.<br>
+3. Propagate the updates to production environment (using rolling updates, Canary or Blue-green update methods).
+
+### If nodes are started with product profiles, how to take the manual Updates ?
+First take the update of the base product and thereafter distribute the updated pack to other deployment environments. 
+Then, run different profiles on those environments as needed.
+
+### How to use Configuration Management Tool to get WUM updates?
+The Following steps are used to get latest WSO2 APIM updates using Ansible as a Configuration Management Tool.<br>
+1. Folk the newest WSO2 APIM Pack for the latest tag. <br>
+2. Run the `update.sh` and update the pack - by performing this action product pack takes its latest state<br>
+3. Checkout tag 3.2.0.x take the latest tag - Ansible scripts will be compatible with the new update model<br>
+4. Take future updates by running the `.update.sh` command. <br>
+
+### A customer who runs on a containerized deployment, How to differentiate docker images created with new updates from WSO2 Docker Repository?
+1. Login to [WSO2 Docker Repository](https://docker.wso2.com/) <br>
+2. In the shown list, choose the product that is used in your deployment environment (To easily explain we will use WSO2 APIM as a product).<br>
+3. Considering the example mentioned above, Choose wso2am as the repository name.<br>
+    Docker images with updates:<br>
+    1. If user is using **three digit version** like wso2am:3.2.0 then switch to e.g.,3.2.0.0 to get docker images created with updates. <br>
+    2. If the customer was **using timestamp** image like wso2am:3.2.0.1612370755920.2 they can switch to an image with specific update level wso2am:3.2.0.8 <br>
+    

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -2,24 +2,27 @@
 
 * Update the current product pack to the latest update level using WUM or in-place tool. This will make the new Update tool
   client available inside `<product_home>/bin` directory.
-* Run the [Update commands](../../updates/update-tool/) on top of the update tool. This will
-  update the product pack to comply with Updates 2.0
+* Run the new Update Tool (e.g., wso2update_linux for linux users) refer [Update commands](../../updates/update-tool/) for other OS's. This will
+  update the product pack to comply with WSO2 Updates 2.0, and the product pack will be in its latest update level.
 
-### How can a user merge the *WUM Diff* manually to get updates using WSO2 Updates 2.0?
-To get Updates using the new WSO2 Updates model follow the steps below<br>
-
-1. First get the newest product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0). <br>
+### How can a user currently using *WUM Diff* migrate to WSO2 Updates 2.0?
+To get updates using the new WSO2 Updates model follow the steps below: <br>
+1. First, get the newest product pack from WUM (Run `wum update <product>` e.g., wum update wso2am-3.0.0).<br>
 2. Apply [WUM diff](https://docs.wso2.com/display/updates100/WUM+Commands+Guide#WUMCommandsGuide-wumdiff) as you have been doing before to a copy of product pack (which contain your customizations). <br>
 
 !!! Note
     The diff ZIP is created in the location from where you executed the diff command.
 <br>
-3. Now your current pack is congruent with WSO2 Update 2.0, thus you are able to run the [Updates tool](../../updates/update-tool/) and receive WSO2 Updates.<br>
-4. Test the updated product distribution and deploy it in your production environment.
+3. Run the new Update Tool (e.g., wso2update_linux for linux users) refer [Update commands](../../updates/update-tool/) for other OS's. This will update the product pack to comply with WSO2 Updates 2.0, and the product pack will be in its latest update level.<br>
+4. Now your current pack is congruent with WSO2 Updates 2.0.<br>
+5. Test the updated product distribution and deploy it in your production environment.
 
-### Is it mandatory to have a configuration management tool configured or can we take the Updates manually?
+### Does the new WSO2 Updates 2.0 support a command similar to *WUM Diff*?
+No, Wum diff in the older/WUM model requires manual intervention. Therefore, it is prone to errors as a result commands that need manual file copying task were excluded from the updates 2.0
+
+### Is it mandatory to have a configuration management tool configured or can we take the Updates manually to the environments?
 It is not mandatory to have a configuration management tool configured, but having a configuration management tool makes the continuous updates process easy, 
-and it aids configuration with less possibility of human error.
+and it aids configuration with less possibility of human errors.
 
 ### What are the correct steps to apply the same Update level to all the nodes in the deployment if a configuration management tool is not being used?
 In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 
@@ -27,24 +30,24 @@ as the manual intervention may lead to some flaws. <br>
 Steps to apply the same update level across all node: <br>
 1. In a pre-production environment, update to the required update level using the --level flag (e.g., ./wso2update_linux --level 10)<br>
 2. Run all testcases and verify the update in that environment.<br>
-3. Propagate the updates to production environment (using rolling updates, Canary or Blue-green update methods).
+3. Propagate the same updated product pack to other and production environments(using rolling updates, Canary or Blue-green update methods).
 
-### If nodes are started with product profiles, how to take the manual Updates?
+### If nodes are started with product profiles, how to take updates?
 First take the update of the base product and thereafter distribute the updated pack to other deployment environments. 
 Then, run different profiles on those environments as needed.
 
 ### How to migrate from WUM to the new Updates model if a Configuration Management Tool is being used ?
 If a Configuration Management Tool is being used, follow the steps below to convert to the new updates model.<br>
-The respective product pack lies in the `files/packs` directory, to migrate to updates2.0 seamlessly you have to make both the product pack, and the `/scripts/update.sh` file compatible with WSO2 Updates 2.0.
+The respective product pack lies in the `files/packs` directory, to migrate to updates 2.0 seamlessly you have to make both the product pack, and the `/scripts/update.sh` file compatible with Updates 2.0.
 <br>
 - To update the **product pack** - Go to` scripts` directory and run the `./update.sh` script.<br>
-- To update **/scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tag, in this example WSO2 APIM.
+- To update **/scripts/update.sh** file - Checkout the latest [v3.2.0.x](https://github.com/wso2/ansible-apim/tags) tags, in this example WSO2 APIM.
 
   ``
-            git checkout v3.2.0.3
+    git checkout v3.2.0.3
   ``
    
-Now your updates setup is compatible with the new updates model. Thus, in the future when the `update.sh` script is executed updates will be delivered using the new updates model.
+Now your updates setup is compatible with the new updates model. Thus, in the future when the `update.sh` script is executed, updates will be delivered using the new updates model.
       
 ### How to differentiate docker images created with new updates from WSO2 Docker Repository?
 1. Login to [WSO2 Docker Repository](https://docker.wso2.com/) <br>

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -1,4 +1,4 @@
-### How do I migrate from WUM and In-place to Updates 2.0?
+### How do I migrate from WUM and In-place to Updates 2.0 ?
 
 * Update the current product pack to the latest update level using WUM or in-place tool. This will make Update tool
   client available inside `<product_home>/bin` directory.

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -36,9 +36,9 @@ Then, run different profiles on those environments as needed.
 ### How to use Configuration Management Tool to get WUM updates?
 The Following steps are used to get latest WSO2 APIM updates using Ansible as a Configuration Management Tool.<br>
 1. Folk the newest WSO2 APIM Pack for the latest tag. <br>
-2. Run the `update.sh` and update the pack - by performing this action product pack takes its latest state<br>
+2. Run the `./update.sh` and update the pack - by performing this action product pack takes its latest state<br>
 3. Checkout tag 3.2.0.x take the latest tag - Ansible scripts will be compatible with the new update model<br>
-4. Take future updates by running the `.update.sh` command. <br>
+4. Take future updates by running the `./update.sh` command. <br>
 
 ### How to differentiate docker images created with new updates from WSO2 Docker Repository?
 1. Login to [WSO2 Docker Repository](https://docker.wso2.com/) <br>

--- a/en/docs/updates/migrating-to-updates2.0.md
+++ b/en/docs/updates/migrating-to-updates2.0.md
@@ -28,8 +28,9 @@ and it aids configuration with less possibility of human errors.
 Refer [APIM Ansible repository Documentation](https://github.com/wso2/ansible-apim/tree/3.2.x#including-custom-keystore-and-truststore) to get an insight on customizing keystore and truststore configurations that are integrated with a configuration management tool.
 
 ### How to persist customizations done on the servers during each update?
-if there are .jar or UI customization those changes should be done on the base pack of the Configuration Management Tool. (e.g., APIM 3.2.0 ansible the customized files should be in `/files` in the suitable directory. further, all .jar files should be added to the `misc` folder)
-next you need to change the script[common task](https://github.com/chamindi-a/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml) to include group customizations or changes. If there are any role specific changes the script changes should be performed in the required role(s).
+1. If there are .jar or UI customization those changes should be done in configuration management server.Those changes should also be pushed to your forked repository, for future use.<br>
+2. The customized files should be in the sub-directories of the `/files` directory. (Particularly, all .jar files and UI customizations should be added to the `misc` folder.)<br>
+3. Next you need to change the script to include [group customizations/changes](https://github.com/wso2/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml). On the contrary, if there are any [role specific changes](https://github.com/wso2/ansible-apim/blob/3.2.x/roles/common/tasks/custom.yml) the script changes should be performed in the respective role(s).
 
 ### What are the correct steps to apply the same Update level to all the nodes in the deployment if a configuration management tool is not being used?
 In some situations' a Configuration Management Tool will not be configured, however WSO2 recommends the use of a Configuration Management Tool to mitigate human errors 

--- a/en/docs/updates/overview.md
+++ b/en/docs/updates/overview.md
@@ -54,7 +54,7 @@ The WSO2 Update service delivers fixes to subscribers in an ease of use format t
 Read more about [WSO2 subscriptions](https://wso2.com/subscription/)<br>
 
 !!! info
-    If you have received updates before using **WUM/Inplace tool** refer [FAQ section](../faq/#how-do-i-migrate-from-wum-and-in-place-to-updates-20) to migrate to WSO2 updates 2.0 model.
+    If you have received updates before using **WUM/Inplace tool** refer [Migrating to updates page](../../updates/migrating-to-updates2.0/) to migrate to WSO2 updates 2.0 model.
 
 ## When to use hotfixes?
 

--- a/en/docs/updates/overview.md
+++ b/en/docs/updates/overview.md
@@ -56,6 +56,7 @@ Read more about [WSO2 subscriptions](https://wso2.com/subscription/)<br>
 !!! info
     If you have received updates before using **WUM/Inplace tool** refer [Migrating to updates page](../../updates/migrating-to-updates2.0/) to migrate to WSO2 updates 2.0 model.
 
+
 ## When to use hotfixes?
 
 When you are faced an issue in your deployment environment, you can raise a ticket at [WSO2 Support](https://support.wso2.com). We will provide you a hotfix for critical issues, which have not been addressed before in any of the previous updates. 

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -49,11 +49,11 @@ nav:
     - Updates :
       - Get Started :
         - 'Overview': 'updates/overview.md'
+        - 'Migrating to Updates 2.0': 'updates/migrating-to-updates2.0.md'
         - 'New to this Release': 'updates/new-in-this-release.md'
       - How to Update :
         - 'Using Update Tool': 'updates/update-tool.md'
         - 'Useful Update Commands': 'updates/update-commands.md'
-        - 'Migrating to Updates 2.0': 'updates/migrating-to-updates2.0.md'
         - 'Resolve Conflicts': 'updates/resolve-conflicts.md'
         - 'Continuous Update': 'updates/continuous-update.md'
       - 'Best Practise': 'updates/best-practices.md'

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - How to Update :
         - 'Using Update Tool': 'updates/update-tool.md'
         - 'Useful Update Commands': 'updates/update-commands.md'
+        - 'Migrating to Updates 2.0': 'updates/migrating-to-updates2.0.md'
         - 'Resolve Conflicts': 'updates/resolve-conflicts.md'
         - 'Continuous Update': 'updates/continuous-update.md'
       - 'Best Practise': 'updates/best-practices.md'


### PR DESCRIPTION
## Purpose
> Adding new page 'Migrating to update 2.0'

## Goals
> Adding new page 'Migrating to update 2.0' this page address several concerns brought to light by the support team.

The issues addressed are :
How do I migrate from WUM and In-place to Updates 2.0?
How can a user merge the *WUM Diff* manually to get updates using WSO2 Updates 2.0?
Is it mandatory to have a configuration management tool configured or can we take the Updates manually?
what’s are the correct steps to apply the same Update level to all the nodes in the deployment if the user has not configured a configuration management tool?
If nodes are started with product profiles, how to take the manual Updates?
How to use Configuration Management Tool to get WUM updates?
A customer who runs on a containerized deployment, How to differentiate docker images created with new updates from WSO2 Docker Repository?
