### PR TITLE
Adding create-update and apply-update command details to documentation

### DIFF
--- a/en/docs/updates/advance-continuous-update.md
+++ b/en/docs/updates/advance-continuous-update.md
@@ -51,7 +51,7 @@ Shown below is the folder structure of the `dev` folder.
 
 2. For more information on executing the update script, please refer to the documentation in `ansible-apim/scripts/update_README.md`.
 3. When the above-mentioned update.sh file is executed, the script brings up the relevant product pack to its latest update level.
-4. While the product pack is brought up-to-date, conflicts could be encountered If the user has made customizations to the pack and will be displayed in the console.
+4. While the product pack is brought up-to-date, conflicts could be encountered if the user has made customizations to the pack and will be displayed in the console.
 5. Therefore, conflicting changes should be resolved by perusing the [resolve conflicts page](../resolve-conflicts/) and thereafter re-running the update.sh file.<br>
 
     [For example `./update.sh -p <profile-name>`]<br>

--- a/en/docs/updates/advance-continuous-update.md
+++ b/en/docs/updates/advance-continuous-update.md
@@ -58,7 +58,7 @@ Shown below is the folder structure of the `dev` folder.
    
    
         ./update.sh -p apim
-** This is also graphically illustrated in the below diagram - step one
+
 <br>
 
 6. After all the conflicts are resolved (Without producing warning or errors) in your current environment, updates are properly installed in the aforementioned environment.<br>
@@ -66,7 +66,7 @@ Shown below is the folder structure of the `dev` folder.
 7. Perform git commit and push the template changes to your repository everytime a successful update has been performed.<br>
    
 8. Disseminate the update to the other deployment environments (dev) using the following command. Now the user can perform their expected test on this environment as the updates are properly propagated to the development environment.<br>
-   ** Shown as step two in the below diagram.<br>
+
     
         ansible-playbook -i dev site.yml
 

--- a/en/docs/updates/best-practices.md
+++ b/en/docs/updates/best-practices.md
@@ -8,14 +8,16 @@ Here are the guidelines and recommendations to receive best update experience wi
     directly applying any updates to your production system, WSO2 always recommends applying any update to lower 
     environments such as testing, development or staging environments which has a similar product distribution as in
     production environment. 
+   
+!!! Note
+    Before you run the update tool, **remember to stop** the product pack from running.
 
-2. Add custom configurations or modifications
-
-    Follow guidelines when adding customization to product pack files. This will reduce the merge conflicts. Refer
+<br>
+2. Add custom configurations or modifications<br>
+   Follow guidelines when adding customization to product pack files. This will reduce the merge conflicts. Refer
     [how to reduce merge conflicts](../updates/resolve-conflicts.md).
-      
-3. Run tests
-
+<br>    
+3. Run tests<br>
     WSO2 thoroughly tests and certifies each update and hotfix released. Regardless of whether an update or hotfix 
     running tests on your update environment ensures that all existing and new functionalities are working perfectly fine.
     

--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -17,13 +17,18 @@ Find out more about [WSO2 Subscriptions](https://wso2.com/subscription/)
 
 ### How often  WSO2 Updates will be releases to the user?
 Updates will be released **bi-weekly** as new update levels. Follow the updates commands in
-[Updates command page](../../updates/update-commands/)
+[updates command page](../../updates/update-commands/)
 
 In production environments, WSO2 will announce urgent security fixes to customers via support JIRAs. In addition, WSO2 will announce all security updates, if any, to the customers monthly. Therefore, It is recommended to update your production environments monthly.
 
 ### How can I update my product pack if my environment doesn't have Internet access?
-First, update the product pack in an environment that has Internet access.
-Thereafter, transfer the updated pack to the lockdown environment.
+1. First, update the product pack in an environment that has Internet access using **create-update** command. <br>
+2. Next, transfer the created zip file securely to your isolated environment(s).<br>
+3. Then run the **apply-update** command pointing the proper zip file location. If you have an older update client tool version, at this point the tool will show a message to re-run the same command.<br>
+[The first run of `apply-update` command will self-update the tool]
+4. Upon running the `apply-update` command again will propagate new updates to that environment easily.    
+
+Learn more on the `create-update` and `apply-update` commands by referring [updates command page](../../updates/update-commands/)
 
 ### Do I need a key to unlock updates for production?
 
@@ -77,7 +82,7 @@ yes, escape the $ sign using escape character '\'.
 ### Should I change configurations when a proxy server/firewall is running?
 
 Yes. WSO2 updates are received by connecting to the `https://api.updates.wso2.com, https://cdn.updates.wso2.com, 
-https://product-dist.wso2.com and https://wso2.com`. If your system connects to 
+https://product-dist.wso2.com and https://wso2.com, https://gateway.api.cloud.wso2.com`. If your system connects to 
 the Update service through a proxy server/firewall, whitelist the above-mentioned endpoints.
 
 Since WSO2 update tool is a command-line tool, the proxy should be configured from your command-line using below 

--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -157,3 +157,26 @@ Naming conversion of docker images is as follows:<br>
 ``
 
 e.g., wso2am:3.2.0.3-spec1-alpine
+
+### How can I receive updates to each node (Dev, Staging and Production) when deployment/server directory is shared among nodes? 
+Updates can be received to nodes when the same is sharing deployment/server directory. Listed below are the recommended ways to achieve this:<br>
+<ul>With the aid of a **Configuration Management Tool**:<br>
+<ol>
+    <li>Stop all running product packs.</li> 
+    <li>Unmount the shared directory from all nodes except the main node of Configuration Management Tool. (If the shared directory is not mounted in the main node of the Config Management setup, the user has to mount it to the main node).<br></li>
+    <li>Execute WSO2 update tool on the main node to update the product pack.<br></li>
+    <li>Using the configuration management tool, transfer the updated pack to the other nodes.<br>
+    <li>Mount the shared directory on other nodes, at this point the update is successful on all the deployment node.<br>
+<ol>
+</ul>
+<ul>Without the aid of a **Configuration Management Tool**:<br>
+<ol>
+    <li>In the deployment, the user has to first stop all product packs.<br></li>
+    <li>Unmount the shared directory (deployment/server) in all servers except in one server/instance.<br></li>
+    <li>Run WSO2 Update Tool to update the product pack with the latest changes (jar, war, and webapp changes).<br></li>
+    <li>If there are conflicts the user has to manually resolve them.[Refer Resolve Conflicts page](../../updates/resolve-conflicts/)<br>
+    <li>This will apply all the updates sent for deployment/server directories from WSO2. <br></li>
+    <li>Copy the updated pack to all other nodes replacing their existing product.<br></li>
+    <li>Mount the shared directory in all nodes and start servers. Now the whole deployment is updated.</li>
+</ol>
+</ul>

--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -180,3 +180,10 @@ Updates can be received to nodes when the same is sharing deployment/server dire
     <li>Mount the shared directory in all nodes and start servers. Now the whole deployment is updated.</li>
 </ol>
 </ul>
+
+### What if my proxy runs only on http: protocol?
+You can achieve this by sending HTTPS traffic to the proxy server using plain http, Change the variable HTTPS_PROXY to be as follows:
+
+``
+    HTTPS_PROXY=https://<proxyIP>:<proxyPort>  ->  HTTPS_PROXY=http://<proxyIP>:<proxyPort>
+``

--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -171,10 +171,10 @@ Updates can be received to nodes when the same is sharing deployment/server dire
 </ul>
 <ul>Without the aid of a **Configuration Management Tool**:<br>
 <ol>
-    <li>In the deployment, the user has to first stop all product packs.<br></li>
+    <li>In the deployment, first stop all product packs.<br></li>
     <li>Unmount the shared directory (deployment/server) in all servers except in one server/instance.<br></li>
     <li>Run WSO2 Update Tool to update the product pack with the latest changes (jar, war, and webapp changes).<br></li>
-    <li>If there are conflicts the user has to manually resolve them.[Refer Resolve Conflicts page](../../updates/resolve-conflicts/)<br>
+    <li>If there are conflicts take steps to manually resolve them.[Refer Resolve Conflicts page](../../updates/resolve-conflicts/)<br>
     <li>This will apply all the updates sent for deployment/server directories from WSO2. <br></li>
     <li>Copy the updated pack to all other nodes replacing their existing product.<br></li>
     <li>Mount the shared directory in all nodes and start servers. Now the whole deployment is updated.</li>

--- a/en/docs/updates/update-commands.md
+++ b/en/docs/updates/update-commands.md
@@ -35,6 +35,9 @@ To find out the latest on WSO2 Update, visit [WSO2 Updates Page](https://wso2.co
       	Update the product upto the given level. The provided level
             may or may not contain the product version.
 
+	-b, --backup       
+        Specify updates backup directory.
+
  	-d, --dry-run
       	Simulate the update in a temporary location.
 
@@ -67,9 +70,11 @@ Here is a list of available subcommands:
 
 | **Sub commands**  | **Detail**                                                                                       |
 |------------------|--------------------------------------------------------------------------------------------------|
+|   apply-hotfix   |      Apply an available hotfix                                                                   |
+|   apply-update   |      Apply updates to an isolated environment                                                    | 
 |   check          |      Check available new levels for the product<br>                                              |
 |   current-state  |      Show current details of the product                                                         |
-|   apply-hotfix   |      Apply an available hotfix                                                                   |
+|   create-update  |      Creates a zip file with updates corresponding to an update level range                      |
 |   revert-hotfix  |      Revert the most recently applied hotfix                                                     |
 |   version        |      Print Update tool version                                                                   |  
 |   help           |      Prints usage details of a command                                                           |
@@ -240,6 +245,62 @@ Current-state command prints the current details of the product. This command re
 Get the current status of the product
  	   
  	    wso2update_linux current-state
+
+### [wso2update_<os\> create-update]()
+
+**Synopsis**
+ 	
+ 	wso2update_linux create-update [options]
+
+**Description**<br>
+`create-update` command produces a zip file containing updates corresponding to an update level range
+that is applied to a product in an environment without Internet access.
+
+**Options**
+ 	
+    -e, --end-level string
+      	Ending update level 
+    -h, --help
+      	Help for create-update 
+    -s, --start-level string
+      	Starting update level
+    -p, --password string
+      	Specify your WSO2 account password 
+    -u, --username string
+      	Specify your WSO2 account email
+    -v, --verbose
+      	Enable verbose mode
+
+**Examples**
+
+Creates a zip file that comprises update level range that is applied to a product.
+ 	   
+ 	    wso2update_linux create-update
+
+### [wso2update_<os\> apply-update]()
+
+**Synopsis**
+ 	
+ 	wso2update_linux apply-update [options]
+
+**Description**<br>
+`apply-update` command pointing to the update zip file would facilitate the propagation of updates to a WSO2 product in a lockdown environment. 
+First apply-update command would ascertain whether the latest version of the update client is being used, if the latest version of the tool is absent the client updates itself.
+Thereafter, it would prompt the user for a re-run of apply-update command.
+
+**Options**
+
+        --continue      Merge resolved conflicts
+        --dry-run       Simulate the update
+    -h, --help          Help for apply-update
+        --revert        Revert to the previous update level
+    -v, --verbose       Enable verbose mode   
+
+**Examples**
+
+Executing the `apply-update` command pointing the update zip file location would facilitate receiving updates to the lockdown environment.
+ 	   
+ 	    wso2update_linux apply-update <path-to-update-zip-file>
 
 ### [wso2update_<os\> apply-hotfix]()
 

--- a/en/docs/updates/update-commands.md
+++ b/en/docs/updates/update-commands.md
@@ -365,23 +365,21 @@ prior to applying the same to a production environment.
 
 **Synopsis**
 
-            wso2update_linux create-docker [flags]
+            wso2update_linux create-docker [Options]
 
 **Examples**
 
-            wso2update_linux create-docker [flags]
+            wso2update_linux create-docker [Options]
 
 **Options**
 
-    -h, --help                help for create-docker
-    --os string               Base OS of the Docker image (default "alpine")
-    -p, --password string     Specify your WSO2 account password
-    -t, --tag string          Value the created image should be tagged with (default "alpine")
+    -h, --help                   help for create-docker
+        --os string              Base OS of the Docker image (default "alpine")
+    -p, --password string        Specify your WSO2 account password
+    -t, --tag string             Value the created image should be tagged with(default "alpine")
 
-    --trial-subscription      Continue with a trial subscription
-    -u, --username string     Specify your WSO2 account email
-
-    Global Flags:
-        -v, --verbose         Enable verbose mode
+        --trial-subscription     Continue with a trial subscription
+    -u, --username string        Specify your WSO2 account email
+    -v, --verbose                Enable verbose mode
 
 Refer our [Webinar on Updates 2.0](https://youtu.be/Z2XeRhzkdpI?t=1050) to witness how you could receive updates with WSO2 Updates 2.0

--- a/en/docs/updates/whats-new.md
+++ b/en/docs/updates/whats-new.md
@@ -1,4 +1,4 @@
-## Whats New?
+
 The new updates model has several features that enhance user experience. Following are the key benefits of WSO2 Updates Model 2.0: 
 
 * Consist of `Hotfixes` to deliver quick fixes to customers for incidents.

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Get Started :
         - 'Overview': 'updates/overview.md'
         - 'Migrating to Updates 2.0': 'updates/migrating-to-updates2.0.md'
-        - 'New to this Release': 'updates/new-in-this-release.md'
+        - 'New on WSO2 Updates': 'updates/whats-new.md'
       - How to Update :
         - 'Using Update Tool': 'updates/update-tool.md'
         - 'Useful Update Commands': 'updates/update-commands.md'


### PR DESCRIPTION
## Purpose
>Adding create-update and apply-update command details to documentation

## Goals
> Adding the newly created commands that assist the user to take updates to a isolated environment easily

