### PR TITLE
Add the new icons to hotfixes/update portal pages and removing the banner 

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -225,7 +225,7 @@ We at WSO2 bring a greater, and an improved software solution when we release a 
             <div class="content" style="">
                 Hotfixes
                 <div class="description" style="">
-                  An effective method to resolve customer reported issues in a pragmatic manner as Hotfixes are deleivered       
+                  An effective method to resolve customer reported issues in a pragmatic manner as Hotfixes are delivered       
                  </div>
             </div>
         </div>   

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -151,12 +151,96 @@ We at WSO2 bring a greater, and an improved software solution when we release a 
     <a style="color: #222222;" href="updates/continuous-update">
         <div>
             <div>
-				<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 62.9 62.9" style="enable-background:new 0 0 60 60;width: 60px;" xml:space="preserve"><style>.st0{fill:none;stroke:#ff7300;stroke-width:1.5;stroke-miterlimit:10}</style><path class="st0" d="M36.4 40.3c0-7.6-6.2-13.8-13.8-13.8S8.9 32.7 8.9 40.3 15 54.1 22.6 54.1c.8 0 1.7-.1 2.4-.2"/><path class="st0" d="M31.4 36.8l5.2 4.6 3.7-6"/><path d="M58.6 4.3c5.2 5.2 4.4 12.4 0 16.7C46 33.6 25.2 6.7 7.2 24.6c-8.3 8.3-8.9 22.2 0 31.1s22.7 8.3 31.1 0C56.5 37.5 29 17.2 41.9 4.3c5.7-5.7 13.2-3.6 16.7 0z" fill="none" stroke="#212a32" stroke-width="1.5" stroke-miterlimit="10"/></svg>
+				<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60; width: 60px" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;stroke:#212A32;stroke-width:1.5;stroke-miterlimit:10;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:none;stroke:#FF7300;stroke-width:1.5;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;stroke:#FF7300;stroke-width:1.5;stroke-miterlimit:10;}
+</style>
+<g>
+	<g>
+		<path class="st0" d="M31.3,31c0,2.9-2.3,5.2-5.2,5.2s-5.2-2.3-5.2-5.2"/>
+		<path class="st0" d="M18.6,5.6c-3.5,5.7-0.9,14.7-4.1,18c-1.8,1.8-3.1,2.6-4,3c-0.6,0.3-1.1,0.9-1.1,1.6l0,1
+			c0,0.8,0.6,1.4,1.3,1.4h30.7c0.7,0,1.3-0.6,1.3-1.4l0-1c0-0.7-0.4-1.4-1.1-1.6c-0.9-0.3-1.8-0.1-4-2.4c-3.4-3.6-0.6-12.9-4.1-18.6
+			C31,1.6,26,2.1,26,2.1S21.1,1.6,18.6,5.6z"/>
+	</g>
+	<g>
+		<path class="st1" d="M7.3,25.3c-3.8-2.5-6.2-6.8-6.2-11.7C1.1,9.1,3.3,5,6.6,2.5"/>
+		<path class="st1" d="M10.5,20.6c-2.2-1.5-3.7-4.1-3.7-7c0-2.7,1.3-5.1,3.3-6.7"/>
+	</g>
+	<path class="st2" d="M27.7,56.5l15.6-15.6c1.2,0.5,2.6,0.8,4,0.8l0.8-0.1c6-0.4,10.8-5.4,10.8-11.5c0-1.8-0.4-3.4-1.1-5L50,32.9
+		c-0.4,0.4-0.9,0.7-1.4,0.9c-1.4,0.5-3,0.2-4.1-0.9c-0.7-0.7-1.1-1.7-1.1-2.7c0-0.5,0.1-0.9,0.3-1.3c0.2-0.5,0.5-1,0.9-1.4l7.7-7.7
+		c-1.5-0.7-3.2-1.2-5-1.2c-6.1,0-11.1,4.8-11.5,10.8l-0.1,0.8c0,1.4,0.3,2.7,0.8,4L20.9,49.7c-2,2-1.9,5.2,0.2,7l0,0
+		C23.1,58.4,25.9,58.3,27.7,56.5z"/>
+</g>
+</svg>
             </div>
             <div class="content" style="">
                 Continuous Update
                 <div class="description" style="">
                   Use the guild to decipher how a continuous management tool could be used to instill updates to other deployment settings.          
+                 </div>
+            </div>
+        </div>   
+    </a>   
+</div>
+<div class="integratorDescription">
+    <a style="color: #222222;" href="updates/hotfixes">
+        <div>
+            <div>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60; width: 60px" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#212A32;stroke-width:1.5;stroke-miterlimit:10;}
+	.st1{fill:#FFFFFF;stroke:#FF7300;stroke-miterlimit:10;}
+	.st2{fill:none;stroke:#FF7300;stroke-width:1.5;stroke-miterlimit:10;}
+	.st8{fill:#1A1A1A;}
+	.st9{fill:none;stroke:#FF7300;stroke-miterlimit:10;}
+</style>
+<g>
+	<g>
+		<path class="st0" d="M54.2,51.8H5.8c-1.8,0-3.3-1.5-3.3-3.3V11.5c0-1.8,1.5-3.3,3.3-3.3h48.4c1.8,0,3.3,1.5,3.3,3.3v36.9
+			C57.5,50.3,56,51.8,54.2,51.8z"/>
+		<line class="st0" x1="2.5" y1="19.3" x2="57.5" y2="19.3"/>
+		<g>
+			<circle class="st1" cx="9.5" cy="13.7" r="2.2"/>
+			<circle class="st1" cx="16.9" cy="13.7" r="2.2"/>
+			<circle class="st1" cx="24.4" cy="13.7" r="2.2"/>
+		</g>
+		<rect x="7.8" y="24.3" class="st1" width="8.6" height="5.7"/>
+		<rect x="7.8" y="32.4" class="st1" width="8.6" height="5.7"/>
+		<rect x="7.8" y="40.4" class="st1" width="8.6" height="5.7"/>
+	</g>
+	<g>
+		<path class="st2" d="M46.9,35c0-6.3-5.1-11.5-11.5-11.5S23.9,28.7,23.9,35s5.1,11.5,11.5,11.5c0.7,0,1.4-0.1,2-0.2"/>
+		<g>
+			<path class="st8" d="M48.9,37.7v8.4h-8.4v-8.4H48.9 M49.9,36.7H39.5v10.4h10.4V36.7L49.9,36.7z"/>
+		</g>
+		<polyline class="st9" points="43.9,32.3 46.8,35.2 49.2,31.9 		"/>
+	</g>
+</g>
+</svg>
+            </div>
+            <div class="content" style="">
+                Hotfixes
+                <div class="description" style="">
+                  An effective method to resolve customer reported issues in a pragmatic manner as Hotfixes are deleivered       
+                 </div>
+            </div>
+        </div>   
+    </a>   
+</div>
+<div class="integratorDescription">
+    <a style="color: #222222;" href="updates/updates-portal">
+        <div>
+            <div>
+				<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 62.9 62.9" style="enable-background:new 0 0 60 60;width: 60px;" xml:space="preserve"><style>.st0{fill:none;stroke:#ff7300;stroke-width:1.5;stroke-miterlimit:10}</style><path class="st0" d="M36.4 40.3c0-7.6-6.2-13.8-13.8-13.8S8.9 32.7 8.9 40.3 15 54.1 22.6 54.1c.8 0 1.7-.1 2.4-.2"/><path class="st0" d="M31.4 36.8l5.2 4.6 3.7-6"/><path d="M58.6 4.3c5.2 5.2 4.4 12.4 0 16.7C46 33.6 25.2 6.7 7.2 24.6c-8.3 8.3-8.9 22.2 0 31.1s22.7 8.3 31.1 0C56.5 37.5 29 17.2 41.9 4.3c5.7-5.7 13.2-3.6 16.7 0z" fill="none" stroke="#212a32" stroke-width="1.5" stroke-miterlimit="10"/></svg>
+            </div>
+            <div class="content" style="">
+                Updates Portal
+                <div class="description" style="">
+                  Displays descriptions and instructions related to specific update as UI presentation         
                  </div>
             </div>
         </div>   

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -44,9 +44,6 @@
             </span>
           {% endif %}
         </div>
-        <div>
-          <span class="beta-badge">This is the new documentation for WSO2 Updates 2.0.0 !</br> To use the Previous WSO2 Updates model, see the <a href="https://docs.wso2.com/display/updates100/Introduction"><u>documentation</u></a>.</span>
-        </div>
         <div class="md-flex__ellipsis md-header__version-select">
           <!--This section should be removed for the GA release -->
           <div class="mb-tabs__dropdown version-select">


### PR DESCRIPTION
## Purpose
This PR address few issues on the documentation page. Those are:
1. Adding a new widget to take the user to the hotfixes page. The widget has a new icon and content.
2. Adding a new widget to take the user to the hotfixes page. The widget has a new icon and content.
3. Further the banner content was removed from the Updates Documentation page as needed
