### PR TITLE
Informing the user to use the ServiceNow portal as the primary source of communication

### DIFF
--- a/en/docs/updates/faq.md
+++ b/en/docs/updates/faq.md
@@ -19,7 +19,7 @@ Find out more about [WSO2 Subscriptions](https://wso2.com/subscription/)
 Updates will be released **bi-weekly** as new update levels. Follow the updates commands in
 [updates command page](../../updates/update-commands/)
 
-In production environments, WSO2 will announce urgent security fixes to customers via support JIRAs. In addition, WSO2 will announce all security updates, if any, to the customers monthly. Therefore, It is recommended to update your production environments monthly.
+In production environments, WSO2 will announce urgent security fixes to customers via the Support Portal. In addition, WSO2 will announce all security updates, if any, to the customers monthly. Therefore, It is recommended to update your production environments monthly.
 
 ### How can I update my product pack if my environment doesn't have Internet access?
 1. First, update the product pack in an environment that has Internet access using **create-update** command. <br>
@@ -71,7 +71,7 @@ You can check details about each update and hotfix in [Updates Portal](https://u
 
 ### What can I do in case of an issue?
 
-If you encounter any issues when using WSO2 updates, report a ticket at Support JIRA. Please be sure to attach the 
+If you encounter any issues when using WSO2 updates, report a issue on Support Portal. Please be sure to attach the 
 details of the error when you report it. You can get the details by getting the log files in `updates/logs` in the product directory.
 
 ### How can I know what changes are included in an update?

--- a/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
+++ b/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
@@ -3,6 +3,5 @@ Follow the steps given below to receive WSO2 Updates using Docker images.<br>
   1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging   format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
   2. Then decide on the correct Docker image tag(s).<br>
   3. Run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
-  3. When an acceptable docker image is created, run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
   4. Rollout the Docker image into a lower environment and test well.<br>
   5. Use this image in other deployments as required.<br>

--- a/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
+++ b/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
@@ -3,5 +3,6 @@ Follow the steps given below to receive WSO2 Updates using Docker images.<br>
   1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging   format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
   2. Then decide on the correct Docker image tag(s).<br>
   3. Run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
+  3. When an acceptable docker image is created, run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
   4. Rollout the Docker image into a lower environment and test well.<br>
   5. Use this image in other deployments as required.<br>

--- a/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
+++ b/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
@@ -3,5 +3,6 @@ Follow the steps given below to receive WSO2 Updates using Docker images.<br>
   1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging   format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
   2. Then decide on the correct Docker image tag(s).<br>
   3. Run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
+  3. When an acceptable docker image is created, run all the security and compliance test(s).   After verifying, add the same to your own private Docker registry.<br>
   4. Rollout the Docker image into a lower environment and test well.<br>
   5. Use this image in other deployments as required.<br>

--- a/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
+++ b/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
@@ -3,6 +3,5 @@ Follow the steps given below to receive WSO2 Updates using Docker images.<br>
   1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging   format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
   2. Then decide on the correct Docker image tag(s).<br>
   3. Run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
-  3. When an acceptable docker image is created, run all the security and compliance test(s).   After verifying, add the same to your own private Docker registry.<br>
   4. Rollout the Docker image into a lower environment and test well.<br>
   5. Use this image in other deployments as required.<br>


### PR DESCRIPTION
## Purpose
>Informing the users to user ServiceNow more regularly when reporting a bug and to get more informed about updates using the ServiceNow portal

## Goals
> As WSO2 shift their use from Jira to ServiceNow the documentation content also should be in line to capture that requirement.

Resolves #89 