### PR TITLE
Inform the users of the docker images been released weekly rather than daily

### DIFF
--- a/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
+++ b/en/docs/updates/how-to-use-docker-images-to-receive-updates.md
@@ -1,7 +1,10 @@
 
 Follow the steps given below to receive WSO2 Updates using Docker images.<br>
-  1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging   format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
+  1. All Docker images in the [WSO2 Private Docker registry](https://docker.wso2.com/) adhere to a special image tagging format. Read more on  [Docker versioning tags](../../updates/using-wso2-docker-images/).<br>
   2. Then decide on the correct Docker image tag(s).<br>
-  3. Run all the security and compliance test(s) on   the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
+  3. Run all the security and compliance test(s) on the selected Docker image. After verifying, add the same to your own private Docker registry.<br>
   4. Rollout the Docker image into a lower environment and test well.<br>
   5. Use this image in other deployments as required.<br>
+
+!!! Note
+    <ins>Docker Image Release Frequency</ins> : Docker images with updates are <strong>released weekly</strong> to the [WSO2 Private Docker registry](https://docker.wso2.com/).Therefore, you will not find continuous update-level tags in the docker images added in the WSO2 Docker registry.

--- a/en/docs/updates/new-user.md
+++ b/en/docs/updates/new-user.md
@@ -1,7 +1,7 @@
 This guide is an introduction to WSO2 Updates 2.0 for fresh users. It provides guidance and direction that you need to start receiving WSO2 Updates with a fresh start.<br>
 
 If you are a novice to WSO2 product update methods, and prefer to use the WSO2 update 2.0 for the first time try the steps given below:<br>
-1. Download the [required product pack](https://wso2.com/) under the 'on-premises' heading.<br>
+1. Download the [required product pack](https://wso2.com/) under the 'Product' heading.<br>
 2. Using the terminal, navigate to the downloaded pack location, unzip the downloaded pack and go to <code>`<product-home>/bin`</code> directory.<br>
 3. Execute the [update commands](../update-tool/#update-commands-for-os) relevant to the OS that is used.
 

--- a/en/docs/updates/update-commands.md
+++ b/en/docs/updates/update-commands.md
@@ -313,8 +313,7 @@ Apply a hotfix to the product
  
 **Description**
 
-Revert-hotfix command reverts most recently applied hotfix to the product distribution. 
-
+Revert-hotfix command reverts the most recently applied hotfix and any configuration that you may have changed while the newest hotfix is installed to the product distribution.
 
 **Options**
 


### PR DESCRIPTION
## Purpose
> Currently, Docker images are released daily with different update levels, However all update levels will be federated and pushed as the next update level to the WSO2 docker registry.

## Goals
> Inform the users of the new decision that will be applied now, to eleminate any confusions.
