### PR TITLE
Correct WSO2 account credentials description in login instructions

### DIFF
--- a/en/docs/updates/wso2-registry-web-portal.md
+++ b/en/docs/updates/wso2-registry-web-portal.md
@@ -5,7 +5,7 @@ The web portal provides a visual interface to browse the projects and images you
 ## **Logging In**
 
 1. Browse URL [**registry.wso2.com**](https://registry.wso2.com).  
-2. Sign in using your standard **WSO2 Account Credentials** (the same email/password used for the Support Portal).
+2. Sign in using your standard **WSO2 Account email address** (the same email used for the Support Portal).
 
 ![Registry login page](../assets/img/updates/registry-portal-login-page.png)
 


### PR DESCRIPTION
This pull request makes a minor update to the login instructions in the WSO2 Registry Web Portal documentation. The change clarifies that only the email address (not the password) from the WSO2 Account is required for signing in.

- Documentation update:
  * Clarified the login step to specify that users should use their WSO2 Account email address, rather than both email and password, when signing in to the web portal.